### PR TITLE
Added cr install dependency

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "null_resource" "create_dirs" {
 
 resource null_resource ibmcloud_crplugin {
   provisioner "local-exec" {
-    command = "ibmcloud plugin install container-registry"
+    command = "${path.module}/scripts/install-cr-plugin.sh"
   }
 }
 

--- a/scripts/install-cr-plugin.sh
+++ b/scripts/install-cr-plugin.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "Instaling CR Plugin"
+
+yes | ibmcloud plugin install container-registry 


### PR DESCRIPTION
Found a small issue when the script tries to create the Container Registry resource it throws an error that 'cr' is not a registered command. See 'ibmcloud help'.  So I added a cr plugin install dependency in main.tf file