### PR TITLE
Fix variable name "cluster_region" which introduced breaking change to iteration-zero install script

### DIFF
--- a/test/stages/stage2-image-registry.tf
+++ b/test/stages/stage2-image-registry.tf
@@ -2,7 +2,7 @@ module "dev_tools_mymodule" {
   source = "./module"
 
   resource_group_name = module.resource_group.name
-  region              = var.region
+  cluster_region      = var.region
   config_file_path    = module.dev_cluster.config_file_path
   ibmcloud_api_key    = var.ibmcloud_api_key
   cluster_namespace   = module.dev_capture_tools_state.namespace


### PR DESCRIPTION
fix variable naming causing ibm-garage-iteration-zero install to fail. Terraform was looking for cluster_region, which was renamed to region. This fix sets the variable to the old name.