### PR TITLE
fixed handling of non-default namespace

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ resource "null_resource" "create_registry_namespace" {
   depends_on = [null_resource.create_dirs, null_resource.ibmcloud_login]
 
   provisioner "local-exec" {
-    command = "${path.module}/scripts/create-registry-namespace.sh ${local.registry_namespace} ${var.region}"
+    command = "${path.module}/scripts/create-registry-namespace.sh ${local.registry_namespace} ${var.resource_group_name} ${var.region}"
 
     environment = {
       KUBECONFIG = var.config_file_path

--- a/scripts/create-registry-namespace.sh
+++ b/scripts/create-registry-namespace.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
-RESOURCE_GROUP="$1"
-REGION="$2"
+REGISTRY_NAMESPACE="$1"
+RESOURCE_GROUP="$2"
+REGION="$3"
 
 # The name of a registry namespace cannot contain uppercase characters
 # Lowercase the resource group name, just in case...
-REGISTRY_NAMESPACE=$(echo "$RESOURCE_GROUP" | tr '[:upper:]' '[:lower:]')
+REGISTRY_NAMESPACE=$(echo "$REGISTRY_NAMESPACE" | tr '[:upper:]' '[:lower:]')
 
 if [[ "${REGION}" =~ "us-" ]]; then
   REGION="us-south"


### PR DESCRIPTION
Fixed handling of non-default namespace, which caused 'resource group not found' error

Signed-off-by: Andrew Trice <amtrice@us.ibm.com>